### PR TITLE
Compatibility with python 3.10+ (Mapping)

### DIFF
--- a/threshold_crypto/data.py
+++ b/threshold_crypto/data.py
@@ -1,5 +1,5 @@
 import base64
-import collections
+from collections.abc import Mapping
 import json
 from typing import Iterable, List, Any, Dict
 
@@ -27,7 +27,7 @@ def _is_ecc_point_list(value):
 
 
 def _is_serialized_ecc_point(value):
-    return isinstance(value, collections.Mapping) and "x" in value and "y" in value and "curve" in value
+    return isinstance(value, Mapping) and "x" in value and "y" in value and "curve" in value
 
 
 def _is_serialized_ecc_point_list(value):


### PR DESCRIPTION
Importing `Mapping` (along with many other names) directly from `collections`, instead of from `collections.abc`, has been deprecated since Python 3.3, and was removed in Python 3.10. So instead of writing `from collections import Mapping`, simply write `from collections.abc import Mapping`, and you should find that no error is raised.